### PR TITLE
Remove private deploy info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,2 @@
 language: node_js
 node_js: node
-deploy:
-  provider: heroku
-  api_key:
-    secure: l1cunEa3k8T73gOstFpYaL4lOy6zASfaViEPjmWP0wzW/PIqF1H2xkKZahKj0t9KFzhpkdPkdDUqUI4Zsvxl/sd7SmSYGtBAzF8Gv6y3tT6Sag54JBYGHc7KVnd3YVf0ZCZZTWtKSL2dcawQg3nd3eaIwd2Yk0Nbd96Vu1/rsCi8yB62OJJYbHeAEtoijlaudeQcPrzdgZQVn0FyTXaLW7D2Kgla69znCdV3a0FCCA6amHI4/a9EZiL5ygrPHYWYI1Hz5/r/k6Qc3L4drlj6HSNgmKMubCnD4nStkaRvpE++s8aaaaKe0kMULQRF+9V6/9nE54cBJo5BchzUg08208lOVqLtTAZztwNqtofkXszeiJU+oC4zwY03sjFrvOjHx56xjs3KG8tlrJvmKqqmLCSrG7QoQnIc3IWjdQAlsiLPQHUHtmfvDWx4JYUCALYYFqxM6P8j61VM3dVghs165HRRdQI9A0xkfxduK4n+QiMbUQuHYSPgT/Gr4w79qh3hlUFs+ksmP6GQn+p/eJCCtg/qWmbyMFtoRTfC3+rXLxGZvg9v/vI1VFkTxhamKdsUmgT1R3w/kKHksl8gk/yF4Ju92ycNuNJP+gu2lHO+DAMPrfLqmZY7Me7ws4/gL5VePmXGygxWQicKL1sb1Zz1B7nMVrfn3O3pRXVFOqfpSvg=
-  app: shrouded-ravine-93286
-  on:
-    repo: sallystudent2017/node-shopping-list-integration-tests


### PR DESCRIPTION
Remove private deploy info for security and it is a better experience for students since they will see how `travis setup heroku`